### PR TITLE
Add flow v3 parameter

### DIFF
--- a/ib_cicd/ib_helpers.py
+++ b/ib_cicd/ib_helpers.py
@@ -224,7 +224,10 @@ def compile_solution(ib_host, api_token, solution_path, relative_flow_path):
                 solution_path, *relative_flow_path.split("/")[:-1]
             ),
             "predefined_binary_path": os.path.join(solution_path, bin_path),
-            "settings": {"flow_file": relative_flow_path.split("/")[-1]},
+            "settings": {
+                "flow_file": relative_flow_path.split("/")[-1],
+                "is_flow_v3": True
+            },
         }
     )
     resp = requests.post(


### PR DESCRIPTION
Add flow v3 parameter to compile solution API call

Previous version would compile a flow binary but you would get an error when running the binary